### PR TITLE
Updated to include s3 and sqs wrappers and to function like a package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+export AWS_S3_ENDPOINT=http://localstack:4572
+export AWS_S3_FORCEPATHSTYLE=true
+export AWS_S3_REGION=us-west-1
+export AWS_SQS_ENDPOINT=http://localstack:4576

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# sudokrew-aws-sdk
+## Sudokrew AWS SDK Module
+
+Services included:
+
+- AWS S3
+- AWS SQS
+
+### Error Formats
+
+Errors unique to SQS functions are handled and thrown.
+Any Common Errors for S3 or SQS will be handled and thrown.
+
+Errors will always return:
+
+- AWS Error Code (ie: `InvalidMessageContents`)
+- AWS Error Description (ie: `The message contains characters outside the allowed set.`)
+- AWS Error Stack Trace

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// import sqs from './sqs';
 const sqs = require('./sqs');
 const s3 = require('./s3');
 const logger = require('./services');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 import sqs from './sqs';
+import s3 from '.s3';
 
 module.exports = {
-  sqs
+  sqs,
+  s3
 }
+
+

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 // import sqs from './sqs';
 const sqs = require('./sqs');
-const s3 = require('.s3');
+const s3 = require('./s3');
+const services = require('./services')
 
 module.exports = {
   sqs,
-  s3
+  s3,
+  services
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 // import sqs from './sqs';
 const sqs = require('./sqs');
 const s3 = require('./s3');
-const services = require('./services')
+const logger = require('./services')
 
 module.exports = {
   sqs,
   s3,
-  services
+  logger
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,10 @@
 // import sqs from './sqs';
 const sqs = require('./sqs');
-import s3 from '.s3';
-import AWS from 'aws-sdk';
-
+const s3 = require('.s3');
 
 module.exports = {
   sqs,
-  s3,
-  AWS
+  s3
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
-import sqs from './sqs';
+// import sqs from './sqs';
+const sqs = require('./sqs');
 import s3 from '.s3';
+import AWS from 'aws-sdk';
+
 
 module.exports = {
   sqs,
-  s3
+  s3,
+  AWS
 }
 
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 // import sqs from './sqs';
 const sqs = require('./sqs');
 const s3 = require('./s3');
-const logger = require('./services')
+const logger = require('./services');
+const aws = require('aws-sdk');
 
 module.exports = {
+  aws,
   sqs,
   s3,
   logger
 }
-
-

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 const sqs = require('./sqs');
 const s3 = require('./s3');
-const logger = require('./services');
 const aws = require('aws-sdk');
 
 module.exports = {
   aws,
   sqs,
-  s3,
-  logger
+  s3
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "aws-sdk": {
-      "version": "2.361.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.361.0.tgz",
-      "integrity": "sha512-dS6R7Ox5IKe1fpNAymaQSumLri6Eq7Gl4qgY4++cbARhMnqCes8f2jpoctlgJB+oZKiZITj2G9bHh5OIKRMlzA==",
+      "version": "2.368.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.368.0.tgz",
+      "integrity": "sha512-pRq4mn6MGthemTcDETBpQ0accSn/VpZEHzjloFmj2KpEavS8FEwhLvatgFqu8zlDunEfARRyL3Gz3FONO8ZFVA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "aws-node",
+  "name": "@sudokrew/aws-node",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "requires": {
-        "lodash": "4.17.11"
-      }
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "aws-sdk": {
       "version": "2.361.0",
@@ -38,173 +35,50 @@
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
-    },
-    "color": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
-      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
-      "requires": {
-        "color-convert": "1.9.3",
-        "color-string": "1.5.3"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "color-string": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
-      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "requires": {
-        "color-name": "1.1.3",
-        "simple-swizzle": "0.2.2"
-      }
-    },
-    "colornames": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
-      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colors": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
-      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
-    "colorspace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
-      "integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
-      "requires": {
-        "color": "3.0.0",
-        "text-hex": "1.0.0"
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "diagnostics": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
-      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
-      "requires": {
-        "colorspace": "1.1.1",
-        "enabled": "1.0.2",
-        "kuler": "1.0.1"
-      }
-    },
-    "enabled": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-      "requires": {
-        "env-variable": "0.0.5"
-      }
-    },
-    "env-variable": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
-      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "events": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
-    "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
-    },
-    "fecha": {
-      "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
-      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "kuler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
-      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
-      "requires": {
-        "colornames": "1.1.1"
-      }
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "logform": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
-      "integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
-      "requires": {
-        "colors": "1.3.2",
-        "fast-safe-stringify": "2.0.6",
-        "fecha": "2.3.3",
-        "ms": "2.1.1",
-        "triple-beam": "1.3.0"
-      }
-    },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
-    "one-time": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
-      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
-    },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "punycode": {
       "version": "1.3.2",
@@ -216,60 +90,15 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "sax": {
       "version": "1.2.1",
       "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "requires": {
-        "is-arrayish": "0.3.2"
-      }
-    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "text-hex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
-    },
-    "triple-beam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "url": {
       "version": "0.10.3",
@@ -280,39 +109,22 @@
         "querystring": "0.2.0"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "winston": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.1.0.tgz",
-      "integrity": "sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==",
+      "version": "2.4.1",
+      "resolved": "http://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "requires": {
-        "async": "2.6.1",
-        "diagnostics": "1.1.1",
-        "is-stream": "1.1.0",
-        "logform": "1.10.0",
-        "one-time": "0.0.4",
-        "readable-stream": "2.3.6",
-        "stack-trace": "0.0.10",
-        "triple-beam": "1.3.0",
-        "winston-transport": "4.2.0"
-      }
-    },
-    "winston-transport": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
-      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
-      "requires": {
-        "readable-stream": "2.3.6",
-        "triple-beam": "1.3.0"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       }
     },
     "xml2js": {
@@ -320,8 +132,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       }
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.361.0",
-    "winston": "^3.1.0"
+    "winston": "2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "description": "Sudokrew maintained NodeJS promise based aws-sdk wrappers with logging service",
   "main": "index.js",
+  "engines": {
+    "node": "10.13.0",
+    "npm": "6.0.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/s3/index.js
+++ b/s3/index.js
@@ -1,5 +1,5 @@
-import s3 from './s3';
-import AWS from 'aws-sdk';
+const s3 = require('./s3');
+const AWS = require('aws-sdk');
 
 module.exports = {
   AWS,

--- a/s3/index.js
+++ b/s3/index.js
@@ -1,0 +1,7 @@
+import s3 from './s3';
+import AWS from 'aws-sdk';
+
+module.exports = {
+  AWS,
+  s3,
+};

--- a/s3/index.js
+++ b/s3/index.js
@@ -1,7 +1,3 @@
 const s3 = require('./s3');
-const AWS = require('aws-sdk');
 
-module.exports = {
-  AWS,
-  s3,
-};
+module.exports = s3;

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -1,6 +1,7 @@
 const AWS = require('aws-sdk');
 const { logger } = require('../services');
-const errorHandler = require('../services/errorHandler');
+const { CommonError } = require('../services/errorHandler');
+
 
 if (!process.env.AWS_S3_ENDPOINT) {
   throw new Error('AWS_S3_ENDPOINT environment variable missing');
@@ -23,7 +24,7 @@ function createBucket(params) {
       return true;
     })
     .catch(err => {
-      errorHandler.getS3Error(err);
+      throw new CommonError(err.code, err.description, err.stack);
     });
 
   return result;
@@ -36,7 +37,7 @@ function bucketExists(params) {
       return true;
     })
     .catch(err => {
-      errorHandler.getS3Error(err);
+      throw new CommonError(err.code, err.description, err.stack);
     });
 
   return result;
@@ -49,7 +50,7 @@ function listBuckets() {
       return data;
     })
     .catch(err => {
-      errorHandler.getS3Error(err);
+      throw new CommonError(err.code, err.description, err.stack);
     });
 
   return result;
@@ -62,7 +63,7 @@ function putObject(params) {
       return data;
     })
     .catch(err => {
-      errorHandler.getS3Error(err);
+      throw new CommonError(err.code, err.description, err.stack);
     });
 
   return result;

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -3,6 +3,7 @@ const { logger } = require('../services');
 
 let s3 = new AWS.S3({ endpoint: 'http://localstack:4572', region: 'us-west-1', s3ForcePathStyle: true });
 
+
 function createBucket(params) {
   const result = s3.createBucket(params).promise()
     .then(data => {

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -1,5 +1,6 @@
 const AWS = require('aws-sdk');
 const { logger } = require('../services');
+const errorHandler = require('../services/errorHandler');
 
 if (!process.env.AWS_S3_ENDPOINT) {
   throw new Error('AWS_S3_ENDPOINT environment variable missing');
@@ -23,8 +24,7 @@ function createBucket(params) {
       return true;
     })
     .catch(err => {
-      logger.error(`Error creating S3 bucket ${params.Bucket} \nError: ${err}`);
-      return false;
+      errorHandler.getS3Error(err);
     });
 
   return result;
@@ -37,8 +37,7 @@ function bucketExists(params) {
       return true;
     })
     .catch(err => {
-      logger.debug(`Bucket ${params.Bucket} does not exist`);
-      return false;
+      errorHandler.getS3Error(err);
     });
 
   return result;
@@ -51,7 +50,7 @@ function listBuckets() {
       return data;
     })
     .catch(err => {
-      logger.error(`Could not retreive bucket list. \n Error: ${err}`);
+      errorHandler.getS3Error(err);
     });
 
   return result;
@@ -65,7 +64,7 @@ function putObject(params) {
       return data;
     })
     .catch(err => {
-      logger.error(`Error writing data to S3 target: ${err}`);
+      errorHandler.getS3Error(err);
     });
 
   return result;

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const { logger } = require('../utils');
+const { logger } = require('../services');
 
 let s3 = new AWS.S3({ endpoint: 'http://localstack:4572', region: 'us-west-1', s3ForcePathStyle: true });
 

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -3,15 +3,6 @@ const { logger } = require('../services');
 
 let s3 = new AWS.S3({ endpoint: 'http://localstack:4572', region: 'us-west-1', s3ForcePathStyle: true });
 
-class CustomError extends Error {
-  constructor(stack = `Successful creation of S3 bucket ${params.Bucket}`) {
-    // super (...params)
-  }
-  //   if(`Successful creation of S3 bucket ${params.Bucket}`) {
-  //   Error.captrue
-  // }
-}
-
 function createBucket(params) {
   const result = s3.createBucket(params).promise()
     .then(data => {
@@ -19,18 +10,10 @@ function createBucket(params) {
       logger.info(`Successful creation of S3 bucket ${params.Bucket}`);
       return true;
     })
-  try {
-    throw new CustomError();
-  } catch (err) {
-    console.log(err.stack, 'stack');
-    // logger.error(err.foo);
-    // logger.error(err.message);
-  }
-
-  //   // if (err instanceof EvalError) {
-  //   //   logger.error(`Error creating S3 bucket ${params.Bucket} \nError: ${err}`);
-  //   // } else { return false }
-  // });
+    .catch(err => {
+      logger.error(`Error creating S3 bucket ${params.Bucket} \nError: ${err}`);
+      return false;
+    });
 
   return result;
 }

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -1,8 +1,19 @@
 const AWS = require('aws-sdk');
 const { logger } = require('../services');
 
-let s3 = new AWS.S3({ endpoint: 'http://localstack:4572', region: 'us-west-1', s3ForcePathStyle: true });
+if (!process.env.AWS_S3_ENDPOINT) {
+  throw new Error('AWS_S3_ENDPOINT environment variable missing');
+} else if (!process.env.AWS_S3_REGION) {
+  throw new Error('AWS_S3_REGION environment variable missing');
+} else if (!process.env.AWS_S3_FORCEPATHSTYLE) {
+  throw new Error('AWS_S3_FORCEPATHSTYLE environment variable missing');
+}
 
+const s3 = new AWS.S3({
+  endpoint: process.env.AWS_S3_ENDPOINT,
+  region: process.env.AWS_S3_REGION,
+  s3ForcePathStyle: process.env.AWS_S3_FORCEPATHSTYLE
+});
 
 function createBucket(params) {
   const result = s3.createBucket(params).promise()

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -1,0 +1,84 @@
+const AWS = require('aws-sdk');
+const { logger } = require('../utils');
+
+let s3 = new AWS.S3({ endpoint: 'http://localstack:4572', region: 'us-west-1', s3ForcePathStyle: true });
+
+class CustomError extends Error {
+  constructor(stack = `Successful creation of S3 bucket ${params.Bucket}`) {
+    // super (...params)
+  }
+  //   if(`Successful creation of S3 bucket ${params.Bucket}`) {
+  //   Error.captrue
+  // }
+}
+
+function createBucket(params) {
+  const result = s3.createBucket(params).promise()
+    .then(data => {
+      logger.debug(data);
+      logger.info(`Successful creation of S3 bucket ${params.Bucket}`);
+      return true;
+    })
+  try {
+    throw new CustomError();
+  } catch (err) {
+    console.log(err.stack, 'stack');
+    // logger.error(err.foo);
+    // logger.error(err.message);
+  }
+
+  //   // if (err instanceof EvalError) {
+  //   //   logger.error(`Error creating S3 bucket ${params.Bucket} \nError: ${err}`);
+  //   // } else { return false }
+  // });
+
+  return result;
+}
+
+function bucketExists(params) {
+  const result = s3.headBucket(params).promise()
+    .then(data => {
+      logger.debug(`Bucket ${params.Bucket} exists`);
+      return true;
+    })
+    .catch(err => {
+      logger.debug(`Bucket ${params.Bucket} does not exist`);
+      return false;
+    });
+
+  return result;
+}
+
+function listBuckets() {
+  const result = s3.listBuckets().promise()
+    .then(data => {
+      logger.debug(`Successfully retrieved bucket list:\n${data}`);
+      return data;
+    })
+    .catch(err => {
+      logger.error(`Could not retreive bucket list. \n Error: ${err}`);
+    });
+
+  return result;
+}
+
+function putObject(params) {
+  const result = s3.putObject(params).promise()
+    .then(data => {
+      logger.info(`Successful write to S3 key: ${params.Key}`);
+      logger.debug(`Successful write to S3 key: ${params.Key}\n Payload: ${params.payload}`);
+      return data;
+    })
+    .catch(err => {
+      logger.error(`Error writing data to S3 target: ${err}`);
+    });
+
+  return result;
+}
+
+module.exports = {
+  putObject,
+  createBucket,
+  listBuckets,
+  bucketExists
+};

--- a/s3/s3.js
+++ b/s3/s3.js
@@ -19,8 +19,7 @@ const s3 = new AWS.S3({
 function createBucket(params) {
   const result = s3.createBucket(params).promise()
     .then(data => {
-      logger.debug(data);
-      logger.info(`Successful creation of S3 bucket ${params.Bucket}`);
+      logger.debug(`Successful creation of S3 bucket ${params.Bucket}`);
       return true;
     })
     .catch(err => {
@@ -59,7 +58,6 @@ function listBuckets() {
 function putObject(params) {
   const result = s3.putObject(params).promise()
     .then(data => {
-      logger.info(`Successful write to S3 key: ${params.Key}`);
       logger.debug(`Successful write to S3 key: ${params.Key}\n Payload: ${params.payload}`);
       return data;
     })

--- a/services/errorHandler.js
+++ b/services/errorHandler.js
@@ -1,45 +1,91 @@
-function getS3Error(err) {
-  if (!err) {
-    throw new Error(null);
-  } else {
-    throw new Error(err);
-  }
+function CommonError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
 }
 
-function getSqsError(err) {
-  if (err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
-    throw new Error(`The specified queue doesn't exist - ${err.code} - HTTP Status Code: 400`)
-  }
-  else if (err.code == 'AWS.SimpleQueueService.QueueDeletedRecently') {
-    throw new Error(`A queue with name ${queueName} was deleted recently. You must wait 60 seconds after deleting a queue before you can create another queue with the same name. - ${err.code}`)
-  }
-  else if (err.code == 'QueueAlreadyExists') {
-    throw new Error(`${err.code} - A queue with name ${queueName} already exists.`)
-  }
-  else if (err.code == 'OverLimit') {
-    throw new Error(`OverLimit error received. Params: ${params}. Stack trace: ${err, err.stack}`);
-  }
-  else if (err.code == 'InvalidIdFormat') {
-    throw new Error(`${err.code} - Invalid ID format for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
-  }
-  else if (err.code == 'ReceiptHandleIsInvalid') {
-    throw new Error(`${err.code} - Receipt handle invalid for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
-  }
-  else if (err.code == 'AWS.SimpleQueueService.UnsupportedOperation') {
-    throw new Error(`${err.code} - Error code 400. Unsupported operation.`)
-  }
-  else if (err.code == 'InvalidMessageContents') {
-    throw new Error(`${err.code} - The message contains characters outside the allowed set. Stack trace: ${err, err.stack}`)
-  }
-  else if (err) {
-    throw new Error(err);
-  }
-  else {
-    throw new Error(null);
-  }
+CommonError.prototype = new Error;
+
+function NonExistentQueueError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
 }
+
+NonExistentQueueError.prototype = new Error;
+
+
+function QueueDeletedRecentlyError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+QueueDeletedRecentlyError.prototype = new Error;
+
+
+function QueueAlreadyExistsError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+QueueAlreadyExistsError.prototype = new Error;
+
+
+function OverLimitError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+OverLimitError.prototype = new Error;
+
+
+function InvalidIdFormatError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+InvalidIdFormatError.prototype = new Error;
+
+
+function ReceiptHandleIsInvalidError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+
+ReceiptHandleIsInvalidError.prototype = new Error;
+
+
+function UnsupportedOperationError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+UnsupportedOperationError.prototype = new Error;
+
+
+function InvalidMessageContentsError(name, message, stack) {
+  this.name = name;
+  this.message = message;
+  this.stack = stack;
+}
+
+InvalidMessageContentsError.prototype = new Error;
 
 module.exports = {
-  getS3Error,
-  getSqsError
-};
+  CommonError,
+  NonExistentQueueError,
+  QueueDeletedRecentlyError,
+  QueueAlreadyExistsError,
+  OverLimitError,
+  InvalidIdFormatError,
+  ReceiptHandleIsInvalidError,
+  UnsupportedOperationError,
+  InvalidMessageContentsError
+}

--- a/services/errorHandler.js
+++ b/services/errorHandler.js
@@ -1,13 +1,40 @@
 function getS3Error(err) {
-  throw new Error('Error Code: AccessDenied, 403 Forbidden');
+  if (!err) {
+    throw new Error(null);
+  } else {
+    throw new Error(err);
+  }
 }
 
 function getSqsError(err) {
   if (err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
-    throw new Error(`The specified queue doesn't exist (AWS.SimpleQueueService.NonExistentQueue) - HTTP Status Code: 400`)
-  } else if (err) {
+    throw new Error(`The specified queue doesn't exist - ${err.code} - HTTP Status Code: 400`)
+  }
+  else if (err.code == 'AWS.SimpleQueueService.QueueDeletedRecently') {
+    throw new Error(`A queue with name ${queueName} was deleted recently. You must wait 60 seconds after deleting a queue before you can create another queue with the same name. - ${err.code}`)
+  }
+  else if (err.code == 'QueueAlreadyExists') {
+    throw new Error(`${err.code} - A queue with name ${queueName} already exists.`)
+  }
+  else if (err.code == 'OverLimit') {
+    throw new Error(`OverLimit error received. Params: ${params}. Stack trace: ${err, err.stack}`);
+  }
+  else if (err.code == 'InvalidIdFormat') {
+    throw new Error(`${err.code} - Invalid ID format for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
+  }
+  else if (err.code == 'ReceiptHandleIsInvalid') {
+    throw new Error(`${err.code} - Receipt handle invalid for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
+  }
+  else if (err.code == 'AWS.SimpleQueueService.UnsupportedOperation') {
+    throw new Error(`${err.code} - Error code 400. Unsupported operation.`)
+  }
+  else if (err.code == 'InvalidMessageContents') {
+    throw new Error(`${err.code} - The message contains characters outside the allowed set. Stack trace: ${err, err.stack}`)
+  }
+  else if (err) {
     throw new Error(err);
-  } else {
+  }
+  else {
     throw new Error(null);
   }
 }

--- a/services/errorHandler.js
+++ b/services/errorHandler.js
@@ -1,0 +1,16 @@
+function getS3Error(err) {
+  throw new Error('Error Code: AccessDenied, 403 Forbidden');
+}
+
+function getSqsError(err) {
+  if (err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
+    throw new Error(`The specified queue doesn't exist (AWS.SimpleQueueService.NonExistentQueue) - HTTP Status Code: 400`)
+  } else if (err) {
+    throw new Error(err);
+  }
+}
+
+module.exports = {
+  getS3Error,
+  getSqsError
+};

--- a/services/errorHandler.js
+++ b/services/errorHandler.js
@@ -7,6 +7,8 @@ function getSqsError(err) {
     throw new Error(`The specified queue doesn't exist (AWS.SimpleQueueService.NonExistentQueue) - HTTP Status Code: 400`)
   } else if (err) {
     throw new Error(err);
+  } else {
+    throw new Error(null);
   }
 }
 

--- a/services/index.js
+++ b/services/index.js
@@ -1,4 +1,4 @@
-import logger from './logger';
+const logger = require('./logger');
 
 module.exports = {
   logger,

--- a/services/index.js
+++ b/services/index.js
@@ -1,3 +1,8 @@
 const logger = require('./logger');
+const errorHandler = require('./errorHandler');
 
-module.exports = logger;
+module.exports = {
+  logger,
+  errorHandler
+}
+

--- a/services/index.js
+++ b/services/index.js
@@ -1,5 +1,3 @@
 const logger = require('./logger');
 
-module.exports = {
-  logger,
-};
+module.exports = logger;

--- a/services/index.js
+++ b/services/index.js
@@ -3,4 +3,3 @@ const logger = require('./logger');
 module.exports = {
   logger,
 };
-

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,6 +1,6 @@
 const winston = require('winston');
 
-const logger = new winston.Logger({
+let logger = winston.createLogger({
   transports: [
     new winston.transports.Console({
       colorize: true,

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,4 +1,4 @@
-import winston from 'winston';
+const winston = require('winston');
 
 const logger = new winston.Logger({
   transports: [

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,6 +1,6 @@
 const winston = require('winston');
 
-let logger = new winston.Logger({
+const logger = new winston.Logger({
   transports: [
     new winston.transports.Console({
       colorize: true,

--- a/services/logger.js
+++ b/services/logger.js
@@ -11,4 +11,3 @@ const logger = new winston.Logger({
 });
 
 module.exports = logger;
-

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,6 +1,6 @@
 const winston = require('winston');
 
-let logger = winston.createLogger({
+let logger = new winston.Logger({
   transports: [
     new winston.transports.Console({
       colorize: true,

--- a/services/logger.js
+++ b/services/logger.js
@@ -10,4 +10,6 @@ const logger = new winston.Logger({
   ],
 });
 
-module.exports = logger;
+module.exports = {
+  logger
+};

--- a/sqs/index.js
+++ b/sqs/index.js
@@ -1,3 +1,11 @@
 import sqs from './sqs';
+import AWS from 'aws-sdk';
 
-module.exports = sqs;
+// AWS.config.update({endpoint: 'http://localstack', region:process.env.AWS_REGION});
+
+aws.config.update(opts);
+
+module.exports = {
+  AWS,
+  sqs,
+};

--- a/sqs/index.js
+++ b/sqs/index.js
@@ -1,9 +1,5 @@
-import sqs from './sqs';
-import AWS from 'aws-sdk';
-
-// AWS.config.update({endpoint: 'http://localstack', region:process.env.AWS_REGION});
-
-aws.config.update(opts);
+const sqs = require('./sqs');
+const AWS = require('aws-sdk');
 
 module.exports = {
   AWS,

--- a/sqs/index.js
+++ b/sqs/index.js
@@ -1,7 +1,3 @@
 const sqs = require('./sqs');
-const AWS = require('aws-sdk');
 
-module.exports = {
-  AWS,
-  sqs,
-};
+module.exports = sqs;

--- a/sqs/sqs.js
+++ b/sqs/sqs.js
@@ -1,7 +1,11 @@
 const { SQS } = require('aws-sdk');
 const { logger } = require('../services');
 
-const sqs = new SQS({ endpoint: 'http://localstack:4576' });
+if (!process.env.AWS_SQS_ENDPOINT) {
+  throw new Error('AWS_SQS_ENDPOINT environment variable missing');
+}
+
+const sqs = new SQS({ endpoint: process.env.AWS_SQS_ENDPOINT });
 
 function getQueueUrl(queueName) {
 

--- a/sqs/sqs.js
+++ b/sqs/sqs.js
@@ -1,50 +1,50 @@
-import { SQS } from 'aws-sdk';
-import { logger } from '../services';
+const { SQS } = require('aws-sdk');
+const { logger } = require('../services');
 
-const sqs = new SQS({endpoint: 'http://localstack:4576'});
+const sqs = new SQS({ endpoint: 'http://localstack:4576' });
 
-function getQueueUrl (queueName){
+function getQueueUrl(queueName) {
 
   const params = {
     QueueName: queueName
   };
 
   const result = sqs.getQueueUrl(params).promise()
-    .then( data => {
+    .then(data => {
       logger.info(`Queue URL retrieved: ${data.QueueUrl}`);
       return data.QueueUrl;
     })
-    .catch( err => {
-      if(err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
+    .catch(err => {
+      if (err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
         logger.info(`Queue: ${queueName} doesn't exist.`);
       }
       else {
         logger.error(`Unknown error retrieving queue URL. Stack trace: ${err}`);
-        throw(new Error(err));
+        throw (new Error(err));
       }
     });
 
   return result;
 }
 
-function createQueue(params){
+function createQueue(params) {
 
   const result = sqs.createQueue(params).promise()
-    .then( data => {
+    .then(data => {
       logger.info(`Queue created: ${data.QueueUrl}`);
       return data.QueueUrl;
     })
-    .catch( err => {
+    .catch(err => {
       if (err.code == 'QueueAlreadyExists') {
         logger.info(`Queue: ${queueName} already exists.`);
       }
-      else if (err.code == 'AWS.SimpleQueueService.QueueDeletedRecently'){
+      else if (err.code == 'AWS.SimpleQueueService.QueueDeletedRecently') {
         logger.error(`Queue: ${queueName} deleted recently`);
-        throw(new Error(err));
+        throw (new Error(err));
       }
       else {
         logger.error(`Unknown error creating queue. Stack trace: ${err}`);
-        throw(new Error(err));
+        throw (new Error(err));
       }
     });
 
@@ -52,62 +52,62 @@ function createQueue(params){
 }
 
 
-function receiveMessage(params){
+function receiveMessage(params) {
 
   const result = sqs.receiveMessage(params).promise()
-    .then( data => {
+    .then(data => {
       logger.info(`Message(s) successfully received from ${params.QueueUrl}`);
       logger.debug(`Message received from queue is: ${JSON.stringify(data)}`);
-      if(data.Messages) {
+      if (data.Messages) {
         return data.Messages;
       }
       return [];
     })
-    .catch( err => {
-      if (err.code == 'OverLimit'){
+    .catch(err => {
+      if (err.code == 'OverLimit') {
         logger.error(`OverLimit error received. Params: ${params}. Stack trace: ${err, err.stack}`);
       }
       else {
         logger.error(`Unknown error receiving message. Stack trace: ${err}`);
-        throw(new Error(err));
+        throw (new Error(err));
       }
     });
 
-    return result;
+  return result;
 }
 
 
-function deleteMessage(params){
+function deleteMessage(params) {
   const result = sqs.deleteMessage(params).promise()
-    .then( data => {
+    .then(data => {
       logger.info(`Message ${params.ReceiptHandle} successfully deleted from ${params.QueueUrl}`);
       return data.RequestId;
     })
-    .catch( err => {
-      if (err.code == 'InvalidIdFormat'){
+    .catch(err => {
+      if (err.code == 'InvalidIdFormat') {
         logger.error(`Invalid ID format for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
       }
-      else if (err.code == 'ReceiptHandleIsInvalid'){
+      else if (err.code == 'ReceiptHandleIsInvalid') {
         logger.error(`Receipt handle invalid for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
       }
       else {
         logger.error(`Unknown error deleting queue message. Stack trace: ${err}`);
-        throw(new Error(err));
+        throw (new Error(err));
       }
     });
 
-    return result;
+  return result;
 }
 
-function sendMessage(params){
+function sendMessage(params) {
   const result = sqs.sendMessage(params).promise()
-  .then( data => {
-    logger.info(`Message successfully delivered to ${params.QueueUrl}`);
-    return data.QueueUrl;
-  })
-  .catch( err => {
+    .then(data => {
+      logger.info(`Message successfully delivered to ${params.QueueUrl}`);
+      return data.QueueUrl;
+    })
+    .catch(err => {
       logger.error(`Error delivering message. Params: ${params}. Stack trace: ${err, err.stack}`);
-  });
+    });
 
   return result;
 }

--- a/sqs/sqs.js
+++ b/sqs/sqs.js
@@ -1,5 +1,6 @@
 const { SQS } = require('aws-sdk');
 const { logger } = require('../services');
+const errorHandler = require('../services/errorHandler');
 
 if (!process.env.AWS_SQS_ENDPOINT) {
   throw new Error('AWS_SQS_ENDPOINT environment variable missing');
@@ -15,17 +16,11 @@ function getQueueUrl(queueName) {
 
   const result = sqs.getQueueUrl(params).promise()
     .then(data => {
-      logger.info(`Queue URL retrieved: ${data.QueueUrl}`);
+      logger.debug(`Queue URL retrieved: ${data.QueueUrl}`);
       return data.QueueUrl;
     })
     .catch(err => {
-      if (err.code == 'AWS.SimpleQueueService.NonExistentQueue') {
-        logger.info(`Queue: ${queueName} doesn't exist.`);
-      }
-      else {
-        logger.error(`Unknown error retrieving queue URL. Stack trace: ${err}`);
-        throw (new Error(err));
-      }
+      errorHandler.getSqsError(err);
     });
 
   return result;
@@ -35,21 +30,11 @@ function createQueue(params) {
 
   const result = sqs.createQueue(params).promise()
     .then(data => {
-      logger.info(`Queue created: ${data.QueueUrl}`);
+      logger.debug(`Queue created: ${data.QueueUrl}`);
       return data.QueueUrl;
     })
     .catch(err => {
-      if (err.code == 'QueueAlreadyExists') {
-        logger.info(`Queue: ${queueName} already exists.`);
-      }
-      else if (err.code == 'AWS.SimpleQueueService.QueueDeletedRecently') {
-        logger.error(`Queue: ${queueName} deleted recently`);
-        throw (new Error(err));
-      }
-      else {
-        logger.error(`Unknown error creating queue. Stack trace: ${err}`);
-        throw (new Error(err));
-      }
+      errorHandler.getSqsError(err);
     });
 
   return result;
@@ -60,7 +45,6 @@ function receiveMessage(params) {
 
   const result = sqs.receiveMessage(params).promise()
     .then(data => {
-      logger.info(`Message(s) successfully received from ${params.QueueUrl}`);
       logger.debug(`Message received from queue is: ${JSON.stringify(data)}`);
       if (data.Messages) {
         return data.Messages;
@@ -68,13 +52,7 @@ function receiveMessage(params) {
       return [];
     })
     .catch(err => {
-      if (err.code == 'OverLimit') {
-        logger.error(`OverLimit error received. Params: ${params}. Stack trace: ${err, err.stack}`);
-      }
-      else {
-        logger.error(`Unknown error receiving message. Stack trace: ${err}`);
-        throw (new Error(err));
-      }
+      errorHandler.getSqsError(err);
     });
 
   return result;
@@ -84,20 +62,11 @@ function receiveMessage(params) {
 function deleteMessage(params) {
   const result = sqs.deleteMessage(params).promise()
     .then(data => {
-      logger.info(`Message ${params.ReceiptHandle} successfully deleted from ${params.QueueUrl}`);
+      logger.debug(`Message ${params.ReceiptHandle} successfully deleted from ${params.QueueUrl}`);
       return data.RequestId;
     })
     .catch(err => {
-      if (err.code == 'InvalidIdFormat') {
-        logger.error(`Invalid ID format for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
-      }
-      else if (err.code == 'ReceiptHandleIsInvalid') {
-        logger.error(`Receipt handle invalid for deleted message. Params: ${params}. Stack trace: ${err, err.stack}`);
-      }
-      else {
-        logger.error(`Unknown error deleting queue message. Stack trace: ${err}`);
-        throw (new Error(err));
-      }
+      errorHandler.getSqsError(err);
     });
 
   return result;
@@ -106,11 +75,11 @@ function deleteMessage(params) {
 function sendMessage(params) {
   const result = sqs.sendMessage(params).promise()
     .then(data => {
-      logger.info(`Message successfully delivered to ${params.QueueUrl}`);
+      logger.debug(`Message successfully delivered to ${params.QueueUrl}`);
       return data.QueueUrl;
     })
     .catch(err => {
-      logger.error(`Error delivering message. Params: ${params}. Stack trace: ${err, err.stack}`);
+      errorHandler.getSqsError(err);
     });
 
   return result;


### PR DESCRIPTION
- Brought in the s3.js and sqs.js and logger files used in the other projects
- Updated to use const require rather than import because there is no babel set up in this repo

Update on Dec 4:
- Added an errorHandler and moved SQS-specific errors to this handler
- Changed the catches in `sqs.js` and `s3.js` to `throw new Error` per the error handler
- Changed the endpoints to read from the `.env` file

- Would like to add tests next